### PR TITLE
chore: add module aliases

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,23 +12,23 @@ import {
 } from 'react-native-safe-area-context';
 
 // Uygulama başlangıç kapısı
-import { InitGate } from './app/boot/InitGate';
+import { InitGate } from '@boot/InitGate';
 
 // Navigasyon
-import { StackNavigator, StackGlobalRef, Screen } from './app/navigation/Stack';
-import { TabNavigator, TabScreen } from './app/navigation/Tabs';
+import { StackNavigator, StackGlobalRef, Screen } from '@navigation/Stack';
+import { TabNavigator, TabScreen } from '@navigation/Tabs';
 
 // Ekranlar
-import { TasksScreen } from './app/screens/Tasks/TasksScreen';
-import { NewTaskSheet } from './app/screens/Tasks/NewTaskSheet';
-import { TaskDetailScreen } from './app/screens/Tasks/TaskDetailScreen';
-import { SettingsScreen } from './app/screens/Settings/SettingsScreen';
-import { ManageListsScreen } from './app/screens/Settings/ManageListsScreen';
-import { ManageLabelsScreen } from './app/screens/Settings/ManageLabelsScreen';
-import { DBCheckScreen } from './app/screens/DBCheckScreen';
+import { TasksScreen } from '@screens/Tasks/TasksScreen';
+import { NewTaskSheet } from '@screens/Tasks/NewTaskSheet';
+import { TaskDetailScreen } from '@screens/Tasks/TaskDetailScreen';
+import { SettingsScreen } from '@screens/Settings/SettingsScreen';
+import { ManageListsScreen } from '@screens/Settings/ManageListsScreen';
+import { ManageLabelsScreen } from '@screens/Settings/ManageLabelsScreen';
+import { DBCheckScreen } from '@screens/DBCheckScreen';
 
 // Navigation helper
-import { Navigation } from './app/navigation/Stack';
+import { Navigation } from '@navigation/Stack';
 
 function App() {
   const systemIsDarkMode = useColorScheme() === 'dark';

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
-import App from '../App';
+import App from '@root/App';
 
 test('renders correctly', async () => {
   await ReactTestRenderer.act(() => {

--- a/app/boot/InitGate.tsx
+++ b/app/boot/InitGate.tsx
@@ -12,7 +12,7 @@ import {
   ActivityIndicator,
   Alert,
 } from 'react-native';
-import { DatabaseManager, seedDatabase, ListsRepository } from '../../src/database';
+import { DatabaseManager, seedDatabase, ListsRepository } from '@database';
 
 interface InitGateProps {
   children: ReactNode;

--- a/app/components/FAB.tsx
+++ b/app/components/FAB.tsx
@@ -12,7 +12,7 @@ import {
   Animated,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { lightTheme } from '../theme/theme';
+import { lightTheme } from '@theme/theme';
 
 interface FABProps {
   onPress: () => void;

--- a/app/components/ListItem.tsx
+++ b/app/components/ListItem.tsx
@@ -10,10 +10,10 @@ import {
   TouchableOpacity,
   StyleSheet,
 } from 'react-native';
-import { lightTheme, getPriorityColor, getStatusColor } from '../theme/theme';
-import { formatDue, isOverdue, isToday } from '../utils/date';
-import { getStatusEmoji, getPriorityEmoji } from '../utils/status';
-import type { Task } from '../../src/database/types';
+import { lightTheme, getPriorityColor, getStatusColor } from '@theme/theme';
+import { formatDue, isOverdue, isToday } from '@utils/date';
+import { getStatusEmoji, getPriorityEmoji } from '@utils/status';
+import type { Task } from '@database/types';
 
 interface ListItemProps {
   task: Task;

--- a/app/components/SegmentedControl.tsx
+++ b/app/components/SegmentedControl.tsx
@@ -11,7 +11,7 @@ import {
   StyleSheet,
   AccessibilityInfo,
 } from 'react-native';
-import { lightTheme } from '../theme/theme';
+import { lightTheme } from '@theme/theme';
 
 // Segment seçenekleri
 export type SegmentOption = 'All' | 'Today' | 'Upcoming' | 'Overdue' | 'Done';

--- a/app/components/Sheet.tsx
+++ b/app/components/Sheet.tsx
@@ -18,7 +18,7 @@ import {
   ScrollView,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { lightTheme } from '../theme/theme';
+import { lightTheme } from '@theme/theme';
 
 const { height: screenHeight } = Dimensions.get('window');
 

--- a/app/screens/DBCheckScreen.tsx
+++ b/app/screens/DBCheckScreen.tsx
@@ -21,7 +21,7 @@ import {
   TasksRepository,
   LabelsRepository,
   SubtasksRepository,
-} from '../../src/database';
+} from '@database';
 
 interface DatabaseStats {
   lists: number;

--- a/app/screens/Settings/ManageLabelsScreen.tsx
+++ b/app/screens/Settings/ManageLabelsScreen.tsx
@@ -18,16 +18,16 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 // Components  
-import { Header } from '../../navigation/Stack';
+import { Header } from '@navigation/Stack';
 
 // Database
 import {
   LabelsRepository,
   type Label,
-} from '../../../src/database';
+} from '@database';
 
 // Theme
-import { lightTheme } from '../../theme/theme';
+import { lightTheme } from '@theme/theme';
 
 // Renk paleti
 const COLOR_PALETTE = [

--- a/app/screens/Settings/ManageListsScreen.tsx
+++ b/app/screens/Settings/ManageListsScreen.tsx
@@ -18,17 +18,17 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 // Components  
-import { Header } from '../../navigation/Stack';
+import { Header } from '@navigation/Stack';
 
 // Database
 import {
   ListsRepository,
   TasksRepository,
   type List,
-} from '../../../src/database';
+} from '@database';
 
 // Theme
-import { lightTheme } from '../../theme/theme';
+import { lightTheme } from '@theme/theme';
 
 // Renk paleti
 const COLOR_PALETTE = [

--- a/app/screens/Settings/SettingsScreen.tsx
+++ b/app/screens/Settings/SettingsScreen.tsx
@@ -16,13 +16,13 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 // Database (dev tools için)
-import { resetAndSeed, smokeTest } from '../../../src/database';
+import { resetAndSeed, smokeTest } from '@database';
 
 // Navigation
-import { Navigation } from '../../navigation/Stack';
+import { Navigation } from '@navigation/Stack';
 
 // Theme
-import { lightTheme } from '../../theme/theme';
+import { lightTheme } from '@theme/theme';
 
 interface SettingsScreenProps {
   isDarkMode: boolean;

--- a/app/screens/Tasks/NewTaskSheet.tsx
+++ b/app/screens/Tasks/NewTaskSheet.tsx
@@ -15,7 +15,7 @@ import {
 } from 'react-native';
 
 // Components
-import { SheetWithHeader } from '../../components/Sheet';
+import { SheetWithHeader } from '@components/Sheet';
 
 // Database
 import {
@@ -24,14 +24,14 @@ import {
   LabelsRepository,
   type List,
   type Label,
-} from '../../../src/database';
+} from '@database';
 
 // Utils
-import { parseDateYYYYMMDD, formatDateYYYYMMDD, now } from '../../utils/date';
-import { getAllPriorities } from '../../utils/status';
+import { parseDateYYYYMMDD, formatDateYYYYMMDD, now } from '@utils/date';
+import { getAllPriorities } from '@utils/status';
 
 // Theme
-import { lightTheme, getPriorityColor } from '../../theme/theme';
+import { lightTheme, getPriorityColor } from '@theme/theme';
 
 interface NewTaskSheetProps {
   isVisible: boolean;

--- a/app/screens/Tasks/TaskDetailScreen.tsx
+++ b/app/screens/Tasks/TaskDetailScreen.tsx
@@ -18,7 +18,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 // Navigation
-import { Header } from '../../navigation/Stack';
+import { Header } from '@navigation/Stack';
 
 // Database  
 import {
@@ -30,17 +30,17 @@ import {
   type List,
   type Label,
 
-} from '../../../src/database';
+} from '@database';
 
 // Utils
-import { formatDateYYYYMMDD, parseDateYYYYMMDD } from '../../utils/date';
-import { getAllStatuses, getAllPriorities } from '../../utils/status';
+import { formatDateYYYYMMDD, parseDateYYYYMMDD } from '@utils/date';
+import { getAllStatuses, getAllPriorities } from '@utils/status';
 
 // Theme
-import { lightTheme, getPriorityColor, getStatusColor } from '../../theme/theme';
+import { lightTheme, getPriorityColor, getStatusColor } from '@theme/theme';
 
 // Components
-import { SubtasksPanel } from './components/SubtasksPanel';
+import { SubtasksPanel } from '@screens/Tasks/components/SubtasksPanel';
 
 interface TaskDetailScreenProps {
   taskId: string;

--- a/app/screens/Tasks/TasksScreen.tsx
+++ b/app/screens/Tasks/TasksScreen.tsx
@@ -17,9 +17,9 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 // Components
-import { SegmentedControl, defaultSegmentOptions, type SegmentOption } from '../../components/SegmentedControl';
-import { FAB } from '../../components/FAB';
-import { ListItem } from '../../components/ListItem';
+import { SegmentedControl, defaultSegmentOptions, type SegmentOption } from '@components/SegmentedControl';
+import { FAB } from '@components/FAB';
+import { ListItem } from '@components/ListItem';
 
 // Database
 import {
@@ -28,14 +28,14 @@ import {
   LabelsRepository,
   type Task,
   type Label,
-} from '../../../src/database';
+} from '@database';
 
 // Utils
-import { startOfToday, endOfToday, now } from '../../utils/date';
-import { isActiveStatus } from '../../utils/status';
+import { startOfToday, endOfToday, now } from '@utils/date';
+import { isActiveStatus } from '@utils/status';
 
 // Theme
-import { lightTheme } from '../../theme/theme';
+import { lightTheme } from '@theme/theme';
 
 interface TasksScreenProps {
   onNewTask: () => void;

--- a/app/screens/Tasks/components/SubtasksPanel.tsx
+++ b/app/screens/Tasks/components/SubtasksPanel.tsx
@@ -15,8 +15,8 @@ import {
   AccessibilityInfo,
 } from 'react-native';
 
-import { SubtasksRepository, type Subtask } from '../../../../src/database';
-import { lightTheme } from '../../../theme/theme';
+import { SubtasksRepository, type Subtask } from '@database';
+import { lightTheme } from '@theme/theme';
 
 interface SubtasksPanelProps {
   taskId: string;

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,22 @@
 module.exports = {
   presets: ['module:@react-native/babel-preset'],
+  plugins: [
+    [
+      'module-resolver',
+      {
+        root: ['.'],
+        extensions: ['.ts', '.tsx', '.js', '.json'],
+        alias: {
+          '@database': './src/database',
+          '@components': './app/components',
+          '@navigation': './app/navigation',
+          '@theme': './app/theme',
+          '@utils': './app/utils',
+          '@boot': './app/boot',
+          '@screens': './app/screens',
+          '@root': '.',
+        },
+      },
+    ],
+  ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,13 @@
 module.exports = {
   preset: 'react-native',
+  moduleNameMapper: {
+    '^@database/(.*)$': '<rootDir>/src/database/$1',
+    '^@components/(.*)$': '<rootDir>/app/components/$1',
+    '^@navigation/(.*)$': '<rootDir>/app/navigation/$1',
+    '^@theme/(.*)$': '<rootDir>/app/theme/$1',
+    '^@utils/(.*)$': '<rootDir>/app/utils/$1',
+    '^@boot/(.*)$': '<rootDir>/app/boot/$1',
+    '^@screens/(.*)$': '<rootDir>/app/screens/$1',
+    '^@root/(.*)$': '<rootDir>/$1',
+  },
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "jest": "^29.6.3",
     "prettier": "2.8.8",
     "react-test-renderer": "19.1.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "babel-plugin-module-resolver": "^5.0.0"
   },
   "engines": {
     "node": ">=18"

--- a/src/database/repositories/labels.ts
+++ b/src/database/repositories/labels.ts
@@ -2,9 +2,9 @@
  * Labels repository - Etiket yönetimi
  */
 
-import { DatabaseManager } from '../db';
-import { Label, TaskLabel } from '../types';
-import { generateId, now } from '../id';
+import { DatabaseManager } from '@database/db';
+import { Label } from '@database/types';
+import { generateId, now } from '@database/id';
 
 export class LabelsRepository {
   

--- a/src/database/repositories/lists.ts
+++ b/src/database/repositories/lists.ts
@@ -2,9 +2,9 @@
  * Lists repository - Liste yönetimi
  */
 
-import { DatabaseManager } from '../db';
-import { List } from '../types';
-import { generateId, now } from '../id';
+import { DatabaseManager } from '@database/db';
+import { List } from '@database/types';
+import { generateId, now } from '@database/id';
 
 export class ListsRepository {
   

--- a/src/database/repositories/subtasks.ts
+++ b/src/database/repositories/subtasks.ts
@@ -2,9 +2,9 @@
  * Subtasks repository - Alt görev yönetimi
  */
 
-import { DatabaseManager } from '../db';
-import { Subtask } from '../types';
-import { generateId, now } from '../id';
+import { DatabaseManager } from '@database/db';
+import { Subtask } from '@database/types';
+import { generateId, now } from '@database/id';
 
 export class SubtasksRepository {
 

--- a/src/database/repositories/tasks.ts
+++ b/src/database/repositories/tasks.ts
@@ -2,9 +2,9 @@
  * Tasks repository - Görev yönetimi
  */
 
-import { DatabaseManager } from '../db';
-import { Task, TaskStatus, TaskPriority, PagingOptions, AgendaRange, TaskWithLabels } from '../types';
-import { generateId, now } from '../id';
+import { DatabaseManager } from '@database/db';
+import { Task, TaskStatus, TaskPriority, PagingOptions, AgendaRange, TaskWithLabels } from '@database/types';
+import { generateId, now } from '@database/id';
 
 export class TasksRepository {
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,17 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-native",
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@database/*": ["src/database/*"],
+      "@components/*": ["app/components/*"],
+      "@navigation/*": ["app/navigation/*"],
+      "@theme/*": ["app/theme/*"],
+      "@utils/*": ["app/utils/*"],
+      "@boot/*": ["app/boot/*"],
+      "@screens/*": ["app/screens/*"],
+      "@root/*": ["*"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add TypeScript baseUrl and path aliases
- configure Babel and Jest to resolve `@*` aliases
- refactor imports to use aliases instead of relative paths

## Testing
- `npm test` *(fails: Cannot find module 'babel-plugin-module-resolver')*
- `npm run lint` *(fails: 32 problems (22 errors, 10 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68ac4577ffb8833292bccda1eb2020f5